### PR TITLE
Replace disposal delay with Handler post mechanism to detect Activity resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Here are a few suggestions of how to provide objects in combination with this li
 
 - When using the Lazy* family of Composables it is recommended that you use `rememberScoped`/`viewModelScoped` outside the scope of Composables created by Lazy
   constructors (e.g. LazyColumn) because there is a chance that a lazy initialized Composable will be disposed of when it is not visible anymore (e.g. scrolled
-  away) and that will also dispose of the `rememberScoped`/`viewModelScoped` object (after a few seconds), this might not be the intended behavior. For more
+  away) and that will also dispose of the `rememberScoped`/`viewModelScoped` object immediately, this might not be the intended behavior. For more
   info see Compose's [State Hoisting](https://developer.android.com/jetpack/compose/state#state-hoisting).
 - When a Composable is used more than once in the same screen with the same input, then the ViewModel (or business logic object) should be provided only once
   with `viewModelScoped` at a higher level in the tree using Compose's [State Hoisting](https://developer.android.com/jetpack/compose/state#state-hoisting).
@@ -277,19 +277,19 @@ This project uses internally a ViewModel as a container to store all scoped View
   <summary>What happens when a Composable is disposed?</summary>
   
 When a Composable is disposed of, we don't know for sure if it will return again later. So at the moment of disposal, we mark in our container the associated
-object to be disposed of after a small delay (currently 5 seconds). During the span of time of this delay, a few things can happen:
+object to be disposed of after the next frame when the Activity is resumed. During the span of time of this next frame, a few things can happen:
 
-- The Composable is not part of the composition anymore after the delay and then the associated object is disposed of. 🚮
+- The Composable is not part of the composition anymore after the next frame and the associated object is disposed of. 🚮
 - The LifecycleOwner of the disposed Composable (i.e. the navigation destination where the Composable lived) is paused (e.g. screen went to background) before
-  the delay finishes. Then the disposal of the scoped object is canceled, but the object is still marked for disposal at a later stage.
+  the next frame happened. Then the disposal of the scoped object is canceled, but the object is still marked for disposal at a later stage.
     - This can happen when the application goes through a configuration change and the container Activity is recreated.
     - Also when the Composable is part of a Fragment that has been pushed to the backstack.
     - And also when the Composable is part of a Compose Navigation destination that has been pushed to the backstack.
 - When the LifecycleOwner of the disposed Composable is resumed (e.g. Fragment comes back to foreground), then the disposal of the associated object is
-  scheduled again to happen after a small delay. At this point two things can happen:
+  scheduled again to happen after the next frame when the Activity is resumed. At this point two things can happen:
     - The Composable becomes part of the composition again and the `rememberScoped`/`viewModelScoped` function restores the associated object while also
-      canceling any pending delayed disposal. 🎉
-    - The Composable is not part of the composition anymore after the delay and then the associated object is disposed of. 🚮
+      cancelling any pending disposal in the next frame when the Activity is resumed. 🎉
+    - The Composable is not part of the composition anymore after the next frame and then the associated object is disposed of. 🚮
 
 > **Note**:
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,10 +10,7 @@ core-ktx = '1.12.0'
 navigation = '2.7.4'
 appcompat = '1.6.1'
 constraintlayout = '2.1.4'
-junit-version = '4.13.2'
-robolectric-version = '4.10.3'
 binary-compatibility-validator = '0.13.2'
-kover = '0.7.3'
 # Compose
 compose-bom = '2023.10.00' # https://developer.android.com/jetpack/compose/bom/bom-mapping
 compose-compiler = '1.5.3'
@@ -26,6 +23,15 @@ hilt = '2.48.1'
 hilt-navigation-compose = '1.0.0'
 # Koin
 koin = '3.5.0'
+# Test
+junit-version = '4.13.2'
+kover = '0.7.3'
+robolectric-version = '4.10.3'
+espresso = "3.5.1"
+testRunner = "1.5.2"
+testRules = "1.5.0"
+junitKtx = "1.1.5"
+
 
 
 [libraries]
@@ -66,6 +72,10 @@ koin-android-test = { module = 'io.insert-koin:koin-android-test', version.ref =
 # Test libraries
 junit = { module = 'junit:junit', version.ref = 'junit-version' }
 robolectric = { module = 'org.robolectric:robolectric', version.ref = 'robolectric-version' }
+espresso = { module = 'androidx.test.espresso:espresso-core', version.ref = 'espresso' }
+test-runner = { module = 'androidx.test:runner', version.ref = 'testRunner' }
+test-rules = { module = 'androidx.test:rules', version.ref = 'testRules' }
+androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
 
 
 [bundles]

--- a/resaca/api/resaca.api
+++ b/resaca/api/resaca.api
@@ -43,6 +43,10 @@ public final class com/sebaslogen/resaca/ScopedViewModelContainer$ExternalKey {
 	public final synthetic fun unbox-impl ()I
 }
 
+public final class com/sebaslogen/resaca/ScopedViewModelContainerKt {
+	public static final field COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS J
+}
+
 public final class com/sebaslogen/resaca/ScopedViewModelOwner {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Ljava/lang/Class;Landroidx/lifecycle/ViewModelProvider$Factory;Landroid/os/Bundle;Landroidx/lifecycle/ViewModelStoreOwner;)V

--- a/resaca/build.gradle.kts
+++ b/resaca/build.gradle.kts
@@ -12,7 +12,6 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = libs.versions.targetSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures { // Enables Jetpack Compose for this module
@@ -34,7 +33,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
-    packagingOptions {
+    packaging {
         resources {
             excludes += setOf(
                 // Exclude AndroidX version files

--- a/resaca/src/main/java/com/sebaslogen/resaca/ScopedViewModelContainer.kt
+++ b/resaca/src/main/java/com/sebaslogen/resaca/ScopedViewModelContainer.kt
@@ -19,16 +19,22 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentSkipListSet
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
+import kotlin.coroutines.coroutineContext
 import kotlin.coroutines.resume
+
+public const val COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS: Long = 1
 
 //TODO: Change docs about delayed disposal + Readme
 /**
@@ -76,6 +82,12 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
      * not required after configuration change.
      */
     private val handler = Handler(Looper.getMainLooper())
+
+    /**
+     * Lock to wait for the first composition after Activity resumes.
+     * This is apparently only required in automated Espresso tests.
+     */
+    private var compositionResumedTimeout = CountDownLatch(1)
 
     /**
      * Mark whether the container of this class (usually a screen like an Activity, a Fragment or a Compose destination)
@@ -126,7 +138,7 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
     ): T {
         @Composable
         fun buildAndStoreObject() = builder.invoke().apply { scopedObjectsContainer[positionalMemoizationKey] = this }
-
+        Log.d("Sebas", "REQUEST CANCEL DISPOSAL OF Object $positionalMemoizationKey - it's being requested again - ${Thread.currentThread().name}")
         cancelDisposal(positionalMemoizationKey)
 
         val originalObject: Any? = scopedObjectsContainer[positionalMemoizationKey]
@@ -259,17 +271,17 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
         if (disposingJobs.containsKey(key)) return // Already disposing, quit
 
         val newDisposingJob = viewModelScope.launch {
-            Log.d("Sebas", "scheduleToDispose")
-            if (!isInForeground) awaitChoreographerFramePostFrontOfQueue() // When in background, wait for the next frame when the Activity is resumed
+            Log.d("Sebas", "scheduleToDispose of $key - ${Thread.currentThread().name}")
+            if (!isInForeground) awaitChoreographerFramePostFrontOfQueue(key) // When in background, wait for the next frame when the Activity is resumed
             withContext(NonCancellable) { // We treat the disposal/remove/clear block as an atomic transaction
-                Log.d("Sebas", "scheduleToDispose REMOVING")
+                Log.d("Sebas", "scheduleToDispose REMOVING $key - ${Thread.currentThread().name}")
                 if (isInForeground || isChangingConfiguration) {
-                    Log.d("Sebas", "scheduleToDispose REMOVED")
+                    Log.d("Sebas", "scheduleToDispose REMOVED $key - ${Thread.currentThread().name}")
                     markedForDisposal.remove(key)
                     scopedObjectKeys.remove(key)
                     scopedObjectsContainer.remove(key)?.also { clearLastDisposedObject(it) }
                 } else {
-                    Log.d("Sebas", "scheduleToDispose NOT REMOVED because we are in the background")
+                    Log.d("Sebas", "scheduleToDispose NOT REMOVED $key because we are in the background - ${Thread.currentThread().name}")
                 }
                 disposingJobs.remove(key)
             }
@@ -288,26 +300,35 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
      * If the Activity never comes back, then the work will be cancelled and
      * the FrameCallback will be removed thanks to the coroutine scope cancellation.
      */
-    private suspend fun awaitChoreographerFramePostFrontOfQueue() {
+    private suspend fun awaitChoreographerFramePostFrontOfQueue(key: String) {
+        val localCoroutineScope = CoroutineScope(coroutineContext)
         suspendCancellableCoroutine { continuation ->
             val frameCallback = Choreographer.FrameCallback {
-                Log.d("Sebas", "FrameCallback executed")
+                Log.d("Sebas", "FrameCallback executed for $key - ${Thread.currentThread().name}")
                 handler.postAtFrontOfQueue { // This needs to be posted and run right after Activity resumes
-                    Log.d("Sebas", "postAtFrontOfQueue")
-                    handler.post {
-                        Log.d("Sebas", "post")
-                        if (!continuation.isCompleted) {
-                            Log.d("Sebas", "post + resume + should remove NOW")
-                            continuation.resume(Unit)
+                    Log.d("Sebas", "postAtFrontOfQueue for $key - ${Thread.currentThread().name}")
+                    localCoroutineScope.launch {
+                        withContext(Dispatchers.IO) { // This needs to be done in IO because it's a blocking call
+                            // This extra wait is needed to make sure Composition happens after resume on Espresso tests
+                            Log.d("Sebas", "waiting resume signal for $key - ${Thread.currentThread().name}")
+                            compositionResumedTimeout.await(COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS) // Wait for Compose lifecycle to resume and first composition to happen
+                        }
+                        Log.d("Sebas", "finished waiting for resume for $key - ${Thread.currentThread().name}")
+                        handler.post {
+                            Log.d("Sebas", "post for $key - ${Thread.currentThread().name}")
+                            if (!continuation.isCompleted) {
+                                Log.d("Sebas", "post + resume + should remove NOW for $key - ${Thread.currentThread().name}")
+                                continuation.resume(Unit)
+                            }
                         }
                     }
                 }
             }
-            Log.d("Sebas", "FrameCallback posted")
+            Log.d("Sebas", "FrameCallback posted for $key - ${Thread.currentThread().name}")
             Choreographer.getInstance().postFrameCallback(frameCallback)
 
             continuation.invokeOnCancellation {
-                Log.d("Sebas", "FrameCallback cancelled")
+                Log.d("Sebas", "FrameCallback cancelled for $key - ${Thread.currentThread().name}")
                 Choreographer.getInstance().removeFrameCallback(frameCallback)
             }
         }
@@ -321,6 +342,7 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
     }
 
     private fun cancelDisposal(key: String) {
+        Log.d("Sebas", "CANCELLING DISPOSAL OF $key - ${Thread.currentThread().name}")
         disposingJobs.remove(key)?.cancel() // Cancel scheduled disposal
         markedForDisposal.remove(key) // Un-mark for disposal in case it's not yet scheduled for disposal
     }
@@ -331,7 +353,7 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
     override fun onCleared() {
         // Cancel disposal jobs, all those references will be garbage collected anyway with this ViewModel
         disposingJobs.forEach { (_, job) -> job.cancel() }
-        Log.d("Sebas", "CLEARING ALL ${scopedObjectsContainer.size} OBJECTS")
+        Log.d("Sebas", "CLEARING ALL ${scopedObjectsContainer.size} OBJECTS - ${Thread.currentThread().name}")
         // Cancel all coroutines, Closeables and ViewModels hosted in this object
         val objectsToClear: MutableList<Any> = scopedObjectsContainer.values.toMutableList()
         while (objectsToClear.isNotEmpty()) {
@@ -348,6 +370,7 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
                 Log.d("Sebas", "ON_RESUME")
                 isInForeground = true
                 isChangingConfiguration = false // Clear this flag when the scope is resumed
+                compositionResumedTimeout.countDown() // Signal that the first composition after resume is happening
                 scheduleToDisposeAfterReturningFromBackground()
             }
 
@@ -359,6 +382,8 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
             Lifecycle.Event.ON_DESTROY -> { // Remove ourselves so that this ViewModel can be garbage collected
                 Log.d("Sebas", "ON_DESTROY")
                 source.lifecycle.removeObserver(this)
+                compositionResumedTimeout.countDown() // Clear any pending waiting latch
+                compositionResumedTimeout = CountDownLatch(1) // Start a new latch for the next time this ViewModel is used after resume
             }
 
             else -> {

--- a/resaca/src/main/java/com/sebaslogen/resaca/ScopedViewModelUtils.kt
+++ b/resaca/src/main/java/com/sebaslogen/resaca/ScopedViewModelUtils.kt
@@ -1,6 +1,7 @@
 package com.sebaslogen.resaca
 
 import android.os.Bundle
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -39,6 +40,7 @@ internal object ScopedViewModelUtils {
         scopedObjectKeys: MutableMap<String, ScopedViewModelContainer.ExternalKey>,
         cancelDisposal: ((String) -> Unit)
     ): T {
+        Log.d("Sebas", "REQUEST CANCEL DISPOSAL OF ViewModel $positionalMemoizationKey - it's being requested again")
         cancelDisposal(positionalMemoizationKey)
 
         val originalScopedViewModelOwner: ScopedViewModelOwner<T>? =

--- a/resaca/src/main/java/com/sebaslogen/resaca/ScopedViewModelUtils.kt
+++ b/resaca/src/main/java/com/sebaslogen/resaca/ScopedViewModelUtils.kt
@@ -1,7 +1,6 @@
 package com.sebaslogen.resaca
 
 import android.os.Bundle
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -40,7 +39,6 @@ internal object ScopedViewModelUtils {
         scopedObjectKeys: MutableMap<String, ScopedViewModelContainer.ExternalKey>,
         cancelDisposal: ((String) -> Unit)
     ): T {
-        Log.d("Sebas", "REQUEST CANCEL DISPOSAL OF ViewModel $positionalMemoizationKey - it's being requested again")
         cancelDisposal(positionalMemoizationKey)
 
         val originalScopedViewModelOwner: ScopedViewModelOwner<T>? =

--- a/resacahilt/build.gradle.kts
+++ b/resacahilt/build.gradle.kts
@@ -14,7 +14,6 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = libs.versions.targetSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
@@ -37,7 +36,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
-    packagingOptions {
+    packaging {
         resources {
             excludes += setOf(
                 // Exclude AndroidX version files

--- a/resacakoin/build.gradle.kts
+++ b/resacakoin/build.gradle.kts
@@ -12,7 +12,6 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = libs.versions.targetSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
@@ -35,7 +34,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
-    packagingOptions {
+    packaging {
         resources {
             excludes += setOf(
                 // Exclude AndroidX version files

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -101,8 +101,6 @@ dependencies {
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit)
     androidTestImplementation(libs.koin.android.test)
-//    androidTestImplementation(libs.kotlin.coroutines.test) // TODO : Remove
-//    androidTestImplementation(libs.junit)
 
 
     // Compose dependencies and integration libs

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -93,6 +93,16 @@ dependencies {
     testImplementation(libs.dagger.hilt.android.testing)
     kaptTest(libs.dagger.hilt.android.compiler)
     testImplementation(libs.koin.android.test)
+    // Espresso dependencies for Activity recreation tests
+    androidTestImplementation(libs.espresso)
+    androidTestImplementation(libs.test.runner)
+    androidTestImplementation(libs.test.rules)
+    androidTestImplementation(libs.androidx.junit.ktx)
+    androidTestImplementation(platform(libs.compose.bom))
+    androidTestImplementation(libs.compose.ui.test.junit)
+    androidTestImplementation(libs.koin.android.test)
+//    androidTestImplementation(libs.kotlin.coroutines.test) // TODO : Remove
+//    androidTestImplementation(libs.junit)
 
 
     // Compose dependencies and integration libs

--- a/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/ComposeActivityRecreationTests.kt
+++ b/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/ComposeActivityRecreationTests.kt
@@ -1,0 +1,60 @@
+package com.sebaslogen.resacaapp.sample
+
+import android.content.Intent
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.sebaslogen.resaca.COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS
+import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
+import com.sebaslogen.resacaapp.sample.ui.main.showSingleScopedViewModel
+import com.sebaslogen.resacaapp.sample.ui.main.viewModelScopedDestination
+import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ComposeActivityRecreationTests : ComposeTestUtils {
+
+    private lateinit var scenario: ActivityScenario<ComposeActivity>
+
+    @get:Rule
+    override val composeTestRule = createEmptyComposeRule()
+
+    @Before
+    fun setUp() {
+        scenario = ActivityScenario.launch(
+            Intent(ApplicationProvider.getApplicationContext(), ComposeActivity::class.java).apply {
+                putExtra(ComposeActivity.START_DESTINATION, viewModelScopedDestination)
+            })
+    }
+
+    @Test
+    fun whenISwitchFromLightModeToNightMode_thenTheOneAndOnlyScopedViewModelThatSOnlyUsedInLightModeIsGone() {
+        // Given the starting screen with ViewModel scoped that is ONLY shown in light mode
+        composeTestRule.waitForIdle()
+        // Find the scoped text fields and grab their texts
+        retrieveTextFromNodeWithTestTag("FakeScopedViewModel Scoped")
+        val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
+        printComposeUiTreeToLog()
+
+        // When I change to night mode and apply the configuration change by recreating the Activity
+        showSingleScopedViewModel = false // This is a fake night-mode change but it will remove Composable after Activity re-creation
+        scenario.recreate()
+        printComposeUiTreeToLog()
+        Thread.sleep(COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS * 1000) // Wait for the ViewModel to be cleared
+        val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
+
+        // Then the scoped ViewModel disappears
+        onNodeWithTestTag("FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
+        assert(finalAmountOfViewModelsCleared == initialAmountOfViewModelsCleared + 1) {
+            "The amount of FakeInjectedViewModel that were cleared after key change ($finalAmountOfViewModelsCleared) " +
+                    "was not higher that the amount before the key change ($initialAmountOfViewModelsCleared)"
+        }
+    }
+}

--- a/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/hilt/ComposeActivityRecreationTests.kt
+++ b/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/hilt/ComposeActivityRecreationTests.kt
@@ -1,0 +1,107 @@
+package com.sebaslogen.resacaapp.sample.hilt
+
+import android.content.Intent
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.sebaslogen.resaca.COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS
+import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
+import com.sebaslogen.resacaapp.sample.ui.main.hiltSingleViewModelScopedDestination
+import com.sebaslogen.resacaapp.sample.ui.main.hiltViewModelScopedDestination
+import com.sebaslogen.resacaapp.sample.ui.main.showSingleScopedViewModel
+import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
+import com.sebaslogen.resacaapp.sample.viewModelsClearedGloballySharedCounter
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ComposeActivityRecreationTests : ComposeTestUtils {
+
+    private lateinit var scenario: ActivityScenario<ComposeActivity>
+
+    @get:Rule
+    override val composeTestRule = createEmptyComposeRule()
+
+    @Before
+    fun setUp() {
+        scenario = ActivityScenario.launch(
+            Intent(ApplicationProvider.getApplicationContext(), ComposeActivity::class.java).apply {
+                putExtra(ComposeActivity.START_DESTINATION, hiltViewModelScopedDestination)
+            })
+    }
+
+    @Test
+    fun whenISwitchFromLightModeToNightMode_thenTheOneAndOnlyHiltScopedViewModelThatSOnlyUsedInLightModeIsGoneAndTheRestStay() {
+        // Given the starting screen with Hilt ViewModel scoped that is ONLY shown in light mode
+        composeTestRule.waitForIdle()
+        // Find the scoped text fields and grab their texts
+        val initialFakeScopedRepoText = retrieveTextFromNodeWithTestTag("FakeRepo Scoped")
+        retrieveTextFromNodeWithTestTag("Hilt FakeInjectedViewModel Scoped")
+        printComposeUiTreeToLog()
+
+        // When I change to night mode and apply the configuration change by recreating the Activity
+        showSingleScopedViewModel = false // This is a fake night-mode change but it will remove Composable after Activity re-creation
+        scenario.recreate()
+        printComposeUiTreeToLog()
+
+        // Then the scoped object is still the same but the Hilt Injected ViewModel disappears
+        // Then the text of the NOT scoped object is different from the original one because it's a new object
+        onNodeWithTestTag("FakeRepo Scoped").assertIsDisplayed().assertTextEquals(initialFakeScopedRepoText)
+        onNodeWithTestTag("Hilt FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
+    }
+
+    @Test
+    fun whenTheActivityIsRecreated_thenTheScopedObjectAndHiltInjectedScopedViewModelRemainTheSame() {
+        // Given the starting screen with Hilt injected ViewModel scoped
+        composeTestRule.waitForIdle()
+        // Find the scoped text fields and grab their texts
+        val initialFakeScopedRepoText = retrieveTextFromNodeWithTestTag("FakeRepo Scoped")
+        val initialHiltFakeScopedViewModelText = retrieveTextFromNodeWithTestTag("Hilt FakeSecondInjectedViewModel Scoped")
+        printComposeUiTreeToLog()
+
+        // When I change to night mode and apply the configuration change by recreating the Activity
+        showSingleScopedViewModel = false // This is a fake night-mode change but it will remove Composable after Activity re-creation
+        scenario.recreate()
+        printComposeUiTreeToLog()
+
+        // Then the scoped objects are still the same
+        onNodeWithTestTag("FakeRepo Scoped").assertIsDisplayed().assertTextEquals(initialFakeScopedRepoText)
+        onNodeWithTestTag("Hilt FakeSecondInjectedViewModel Scoped").assertIsDisplayed().assertTextEquals(initialHiltFakeScopedViewModelText)
+    }
+
+    @Test
+    fun whenISwitchFromLightModeToNightMode_thenTheOneAndOnlyHiltScopedViewModelThatSOnlyUsedInLightModeIsGone() {
+        // Given the starting screen with ViewModel scoped that is ONLY shown in light mode
+        scenario = ActivityScenario.launch(
+            Intent(ApplicationProvider.getApplicationContext(), ComposeActivity::class.java).apply {
+                putExtra(ComposeActivity.START_DESTINATION, hiltSingleViewModelScopedDestination)
+            })
+        scenario.recreate()
+        composeTestRule.waitForIdle()
+        // Find the scoped text fields and grab their texts
+        retrieveTextFromNodeWithTestTag("Hilt FakeInjectedViewModel Scoped")
+        val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
+        printComposeUiTreeToLog()
+
+        // When I change to night mode and apply the configuration change by recreating the Activity
+        showSingleScopedViewModel = false // This is a fake night-mode change but it will remove Composable after Activity re-creation
+        scenario.recreate()
+        printComposeUiTreeToLog()
+        Thread.sleep(COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS * 1000) // Wait for the ViewModel to be cleared
+        val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
+
+        // Then the scoped ViewModel disappears
+        onNodeWithTestTag("Hilt FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
+        assert(finalAmountOfViewModelsCleared == initialAmountOfViewModelsCleared + 1) {
+            "The amount of FakeInjectedViewModel that were cleared after key change ($finalAmountOfViewModelsCleared) " +
+                    "was not higher that the amount before the key change ($initialAmountOfViewModelsCleared)"
+        }
+    }
+}

--- a/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/koin/ComposeActivityRecreationTests.kt
+++ b/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/koin/ComposeActivityRecreationTests.kt
@@ -1,0 +1,106 @@
+package com.sebaslogen.resacaapp.sample.koin
+
+import android.content.Intent
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.sebaslogen.resaca.COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS
+import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
+import com.sebaslogen.resacaapp.sample.ui.main.koinSingleViewModelScopedDestination
+import com.sebaslogen.resacaapp.sample.ui.main.koinViewModelScopedDestination
+import com.sebaslogen.resacaapp.sample.ui.main.showSingleScopedViewModel
+import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
+import com.sebaslogen.resacaapp.sample.viewModelsClearedGloballySharedCounter
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ComposeActivityRecreationTests : ComposeTestUtils {
+
+    private lateinit var scenario: ActivityScenario<ComposeActivity>
+
+    @get:Rule
+    override val composeTestRule = createEmptyComposeRule()
+
+    @Before
+    fun setUp() {
+        scenario = ActivityScenario.launch(
+            Intent(ApplicationProvider.getApplicationContext(), ComposeActivity::class.java).apply {
+                putExtra(ComposeActivity.START_DESTINATION, koinViewModelScopedDestination)
+            })
+    }
+
+    @Test
+    fun whenISwitchFromLightModeToNightMode_thenTheOneAndOnlyKoinScopedViewModelThatSOnlyUsedInLightModeIsGoneAndTheRestStay() {
+        // Given the starting screen with Koin ViewModel scoped that is ONLY shown in light mode
+        composeTestRule.waitForIdle()
+        // Find the scoped text fields and grab their texts
+        val initialFakeScopedRepoText = retrieveTextFromNodeWithTestTag("FakeRepo Scoped")
+        retrieveTextFromNodeWithTestTag("Koin FakeInjectedViewModel Scoped")
+        printComposeUiTreeToLog()
+
+        // When I change to night mode and apply the configuration change by recreating the Activity
+        showSingleScopedViewModel = false // This is a fake night-mode change but it will remove Composable after Activity re-creation
+        scenario.recreate()
+        printComposeUiTreeToLog()
+
+        // Then the scoped object is still the same but the Koin Injected ViewModel disappears
+        // Then the text of the NOT scoped object is different from the original one because it's a new object
+        onNodeWithTestTag("FakeRepo Scoped").assertIsDisplayed().assertTextEquals(initialFakeScopedRepoText)
+        onNodeWithTestTag("Koin FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
+    }
+
+    @Test
+    fun whenTheActivityIsRecreated_thenTheScopedObjectAndKoinInjectedScopedViewModelRemainTheSame() {
+        // Given the starting screen with Koin injected ViewModel scoped
+        composeTestRule.waitForIdle()
+        // Find the scoped text fields and grab their texts
+        val initialFakeScopedRepoText = retrieveTextFromNodeWithTestTag("FakeRepo Scoped")
+        val initialKoinFakeScopedViewModelText = retrieveTextFromNodeWithTestTag("Koin FakeInjectedViewModel Scoped")
+        printComposeUiTreeToLog()
+
+        // When we recreate the activity
+        scenario.recreate()
+        printComposeUiTreeToLog()
+
+        // Then the scoped objects are still the same
+        onNodeWithTestTag("FakeRepo Scoped").assertIsDisplayed().assertTextEquals(initialFakeScopedRepoText)
+        onNodeWithTestTag("Koin FakeInjectedViewModel Scoped").assertIsDisplayed().assertTextEquals(initialKoinFakeScopedViewModelText)
+    }
+
+    @Test
+    fun whenISwitchFromLightModeToNightMode_thenTheOneAndOnlyKoinScopedViewModelThatSOnlyUsedInLightModeIsGone() {
+        // Given the starting screen with ViewModel scoped that is ONLY shown in light mode
+        scenario = ActivityScenario.launch(
+            Intent(ApplicationProvider.getApplicationContext(), ComposeActivity::class.java).apply {
+                putExtra(ComposeActivity.START_DESTINATION, koinSingleViewModelScopedDestination)
+            })
+        scenario.recreate()
+        composeTestRule.waitForIdle()
+        // Find the scoped text fields and grab their texts
+        retrieveTextFromNodeWithTestTag("Koin FakeInjectedViewModel Scoped")
+        val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
+        printComposeUiTreeToLog()
+
+        // When I change to night mode and apply the configuration change by recreating the Activity
+        showSingleScopedViewModel = false // This is a fake night-mode change but it will remove Composable after Activity re-creation
+        scenario.recreate()
+        printComposeUiTreeToLog()
+        Thread.sleep(COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS * 1000) // Wait for the ViewModel to be cleared
+        val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
+
+        // Then the scoped ViewModel disappears
+        onNodeWithTestTag("Koin FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
+        assert(finalAmountOfViewModelsCleared == initialAmountOfViewModelsCleared + 1) {
+            "The amount of FakeInjectedViewModel that were cleared after key change ($finalAmountOfViewModelsCleared) " +
+                    "was not higher that the amount before the key change ($initialAmountOfViewModelsCleared)"
+        }
+    }
+}

--- a/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/utils/ComposeTestUtils.kt
+++ b/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/utils/ComposeTestUtils.kt
@@ -1,28 +1,37 @@
 package com.sebaslogen.resacaapp.sample.utils
 
-import androidx.compose.ui.test.*
+import android.content.Intent
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.printToLog
 import androidx.compose.ui.text.AnnotatedString
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
+import com.sebaslogen.resacaapp.sample.ui.main.koinViewModelScopedDestination
 import com.sebaslogen.resacaapp.sample.ui.main.showSingleScopedViewModel
 import org.junit.After
 import org.junit.Before
 import org.koin.core.context.stopKoin
-import org.robolectric.shadows.ShadowLog
 
 interface ComposeTestUtils {
 
-    val composeTestRule: ComposeContentTestRule
+    val composeTestRule: ComposeTestRule
 
     @Before
-    @Throws(Exception::class)
-    fun setUp() {
-        ShadowLog.stream = System.out // Redirect Logcat to console output to read printToLog Compose debug messages
+    fun internalSetUp() {
         showSingleScopedViewModel = null
     }
 
     @After
-    fun tearDown() {
-        stopKoin()
+    fun internalTearDown() {
         showSingleScopedViewModel = null
     }
 

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/MainActivity.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/MainActivity.kt
@@ -6,8 +6,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.sebaslogen.resaca.ScopedViewModelContainer
 import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
 import com.sebaslogen.resacaapp.sample.ui.main.MainFragment
 import com.sebaslogen.resacaapp.sample.ui.main.compose.DemoScreenInActivity

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/MainActivity.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/MainActivity.kt
@@ -6,12 +6,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.sebaslogen.resaca.ScopedViewModelContainer
 import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
 import com.sebaslogen.resacaapp.sample.ui.main.MainFragment
 import com.sebaslogen.resacaapp.sample.ui.main.compose.DemoScreenInActivity

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/ComposeActivity.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/ComposeActivity.kt
@@ -2,6 +2,9 @@ package com.sebaslogen.resacaapp.sample.ui.main
 
 import android.app.Activity
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -44,8 +47,15 @@ import dagger.hilt.android.AndroidEntryPoint
 const val rememberScopedDestination = "rememberScopedDestination"
 const val viewModelScopedDestination = "viewModelScopedDestination"
 const val hiltViewModelScopedDestination = "hiltViewModelScopedDestination"
+const val hiltSingleViewModelScopedDestination = "hiltSingleViewModelScopedDestination"
 const val koinViewModelScopedDestination = "koinViewModelScopedDestination"
+const val koinSingleViewModelScopedDestination = "koinSingleViewModelScopedDestination"
 
+/**
+ * This global boolean is only used in automated tests to fake
+ * the configuration change + activity re-creation + composable gone from composition.
+ */
+var showSingleScopedViewModel: Boolean? = null
 
 @AndroidEntryPoint // This annotation is required for Hilt to work anywhere inside this Activity
 class ComposeActivity : ComponentActivity() {
@@ -54,8 +64,26 @@ class ComposeActivity : ComponentActivity() {
         const val START_DESTINATION = "START_DESTINATION"
     }
 
+    override fun onPause() {
+        super.onPause()
+        Log.d("Sebas", "PAUSE")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        Log.d("Sebas", "RESUME")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d("Sebas", "DESTROY")
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.d("Sebas", "CREATE")
+        val handler = Handler(Looper.getMainLooper())
+        handler.post { Log.d("Sebas", "Posted ON_CREATE") }
 
         setContent {
             ResacaAppTheme {
@@ -88,8 +116,14 @@ fun ScreensWithNavigation(navController: NavHostController = rememberNavControll
         composable(hiltViewModelScopedDestination) {
             ComposeScreenWithHiltViewModelScoped(navController)
         }
+        composable(hiltSingleViewModelScopedDestination) { // This destination is only used in automated tests
+            ComposeScreenWithSingleHiltViewModelScoped(navController)
+        }
         composable(koinViewModelScopedDestination) {
             ComposeScreenWithKoinViewModelScoped(navController)
+        }
+        composable(koinSingleViewModelScopedDestination) { // This destination is only used in automated tests
+            ComposeScreenWithSingleKoinViewModelScoped(navController)
         }
     }
 }
@@ -122,7 +156,7 @@ private fun ComposeScreenWithSingleViewModelScoped(navController: NavHostControl
             text = "The ViewModel below will be shown in light mode and garbage collected in dark mode"
         )
         // The ViewModel is only shown in light mode, to demo how the ViewModel is properly garbage collected in a different config (dark mode)
-        if (!isSystemInDarkTheme()) {
+        if (showSingleScopedViewModel ?: !isSystemInDarkTheme()) {
             DemoScopedViewModelComposable()
         }
         NavigationButtons(navController)
@@ -142,10 +176,31 @@ private fun ComposeScreenWithHiltViewModelScoped(navController: NavHostControlle
             text = "The Hilt ViewModel below will be shown in light mode and garbage collected in dark mode"
         )
         // The Hilt Injected ViewModel is only shown in light mode, to demo how the ViewModel is properly garbage collected in a different config (dark mode)
-        if (!isSystemInDarkTheme()) {
+        if (showSingleScopedViewModel ?: !isSystemInDarkTheme()) {
             DemoScopedHiltInjectedViewModelComposable()
         }
         DemoScopedSecondHiltInjectedViewModelComposable()
+        NavigationButtons(navController)
+    }
+}
+
+/**
+ * This Screen is only used in automated tests
+ */
+@Composable
+private fun ComposeScreenWithSingleHiltViewModelScoped(navController: NavHostController) {
+    Column(
+        modifier = Modifier.verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            modifier = Modifier.padding(8.dp),
+            text = "The ViewModel below will be shown in light mode and garbage collected in dark mode"
+        )
+        // The ViewModel is only shown in light mode, to demo how the ViewModel is properly garbage collected in a different config (dark mode)
+        if (showSingleScopedViewModel ?: !isSystemInDarkTheme()) {
+            DemoScopedHiltInjectedViewModelComposable()
+        }
         NavigationButtons(navController)
     }
 }
@@ -165,10 +220,31 @@ private fun ComposeScreenWithKoinViewModelScoped(navController: NavHostControlle
             text = "The Koin ViewModel below will be shown in light mode and garbage collected in dark mode"
         )
         // The Koin Injected ViewModel is only shown in light mode, to demo how the ViewModel is properly garbage collected in a different config (dark mode)
-        if (!isSystemInDarkTheme()) {
+        if (showSingleScopedViewModel ?: !isSystemInDarkTheme()) {
             DemoScopedKoinInjectedViewModelComposable()
         }
         DemoScopedSecondKoinInjectedViewModelComposable()
+        NavigationButtons(navController)
+    }
+}
+
+/**
+ * This Screen is only used in automated tests
+ */
+@Composable
+private fun ComposeScreenWithSingleKoinViewModelScoped(navController: NavHostController) {
+    Column(
+        modifier = Modifier.verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            modifier = Modifier.padding(8.dp),
+            text = "The ViewModel below will be shown in light mode and garbage collected in dark mode"
+        )
+        // The ViewModel is only shown in light mode, to demo how the ViewModel is properly garbage collected in a different config (dark mode)
+        if (showSingleScopedViewModel ?: !isSystemInDarkTheme()) {
+            DemoScopedKoinInjectedViewModelComposable()
+        }
         NavigationButtons(navController)
     }
 }

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/ComposeActivity.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/ComposeActivity.kt
@@ -2,9 +2,6 @@ package com.sebaslogen.resacaapp.sample.ui.main
 
 import android.app.Activity
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -64,26 +61,8 @@ class ComposeActivity : ComponentActivity() {
         const val START_DESTINATION = "START_DESTINATION"
     }
 
-    override fun onPause() {
-        super.onPause()
-        Log.d("Sebas", "PAUSE")
-    }
-
-    override fun onResume() {
-        super.onResume()
-        Log.d("Sebas", "RESUME")
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        Log.d("Sebas", "DESTROY")
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Log.d("Sebas", "CREATE")
-        val handler = Handler(Looper.getMainLooper())
-        handler.post { Log.d("Sebas", "Posted ON_CREATE") }
 
         setContent {
             ResacaAppTheme {

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/data/FakeInjectedViewModel.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/data/FakeInjectedViewModel.kt
@@ -29,7 +29,7 @@ class FakeInjectedViewModel @Inject constructor(
     val viewModelId = stateSaver.get<Int>(MY_ARGS_KEY)
 
     override fun onCleared() {
-        super.onCleared()
         viewModelsClearedCounter.incrementAndGet()
+        super.onCleared()
     }
 }

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/data/FakeScopedViewModel.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/data/FakeScopedViewModel.kt
@@ -27,7 +27,7 @@ class FakeScopedViewModel(private val stateSaver: SavedStateHandle) : ViewModel(
     private val viewModelsClearedCounter: AtomicInteger = viewModelsClearedGloballySharedCounter
 
     override fun onCleared() {
-        super.onCleared()
         viewModelsClearedCounter.incrementAndGet()
+        super.onCleared()
     }
 }

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/data/FakeSecondInjectedViewModel.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/data/FakeSecondInjectedViewModel.kt
@@ -20,7 +20,7 @@ class FakeSecondInjectedViewModel @Inject constructor(
 ) : ViewModel() {
 
     override fun onCleared() {
-        super.onCleared()
         viewModelsClearedCounter.incrementAndGet()
+        super.onCleared()
     }
 }

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/data/FakeSimpleInjectedViewModel.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/data/FakeSimpleInjectedViewModel.kt
@@ -21,7 +21,7 @@ class FakeSimpleInjectedViewModel @Inject constructor(
 ) : ViewModel() {
 
     override fun onCleared() {
-        super.onCleared()
         viewModelsClearedCounter.incrementAndGet()
+        super.onCleared()
     }
 }

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearRememberScopedObjectTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearRememberScopedObjectTests.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.sebaslogen.resaca.COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS
 import com.sebaslogen.resacaapp.sample.ui.main.compose.examples.DemoScopedObjectComposable
 import com.sebaslogen.resacaapp.sample.ui.main.data.FakeRepo
 import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
@@ -50,7 +51,7 @@ class ClearRememberScopedObjectTests : ComposeTestUtils {
         val initialAmountOfCloseableClosed = closeableClosedGloballySharedCounter.get()
         composablesShown = false // Trigger disposal
         composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
-        advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+        advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
         printComposeUiTreeToLog()
         val finalAmountOfCloseableClosed = closeableClosedGloballySharedCounter.get()
 
@@ -84,7 +85,7 @@ class ClearRememberScopedObjectTests : ComposeTestUtils {
             val initialAmountOfCloseablesCleared = closeableClosedGloballySharedCounter.get()
             composablesShown = false // Trigger disposal
             composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
-            advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
             printComposeUiTreeToLog()
             val finalAmountOfCloseablesCleared = closeableClosedGloballySharedCounter.get()
 

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearRememberScopedObjectTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearRememberScopedObjectTests.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.sebaslogen.resaca.COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS
 import com.sebaslogen.resacaapp.sample.ui.main.compose.examples.DemoScopedObjectComposable
 import com.sebaslogen.resacaapp.sample.ui.main.data.FakeRepo
 import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearScopedViewModelTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearScopedViewModelTests.kt
@@ -92,7 +92,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
         val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
         composablesShown = false // Trigger disposal
         composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
-        advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+        advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
         printComposeUiTreeToLog()
         val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 
@@ -126,7 +126,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
             val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
             composablesShown = false // Trigger disposal
             composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
-            advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
             printComposeUiTreeToLog()
             val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/hilt/ClearScopedViewModelTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/hilt/ClearScopedViewModelTests.kt
@@ -102,7 +102,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
         composablesShown = false // Trigger disposal
         printComposeUiTreeToLog() // Required to trigger recomposition
         onNodeWithTestTag("Hilt FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
-        advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+        advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
         printComposeUiTreeToLog()
         val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 
@@ -135,7 +135,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
             val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
             composablesShown = false // Trigger disposal
             composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
-            advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
             printComposeUiTreeToLog()
             val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 
@@ -168,7 +168,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
             val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
             composablesShown = false // Trigger disposal
             composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
-            advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
             printComposeUiTreeToLog()
             val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/hilt/ClearScopedViewModelTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/hilt/ClearScopedViewModelTests.kt
@@ -210,44 +210,4 @@ class ClearScopedViewModelTests : ComposeTestUtils {
                     "was not two numbers higher that the amount before the key change ($initialAmountOfViewModelsCleared)"
         }
     }
-
-
-    @Test
-    fun `when I switch from light mode to night mode, then the one and only scoped ViewModel that's only used in light mode is gone`() = runTest {
-        // Given the starting screen with ViewModel scoped that is ONLY shown in light mode
-        composeTestRule.activity.setContent {
-            Text("Demo text")
-            if (!isSystemInDarkTheme()) {
-                DemoScopedHiltInjectedViewModelComposable()
-            }
-        }
-        printComposeUiTreeToLog()
-        // Find the scoped text fields and grab their texts
-        retrieveTextFromNodeWithTestTag("Hilt FakeInjectedViewModel Scoped")
-        advanceTimeBy(1000) // Give time to the ObserveLifecycleWithScopedViewModelContainer to execute lifecycle.addObserver on main thread
-
-        // When I change to night mode and apply the configuration change by recreating the Activity
-        RuntimeEnvironment.setQualifiers("+night") // This triggers activity re-creation
-        composeTestRule.activity.setContent { // Almost empty screen in night mode
-            Text("Demo text")
-            if (!isSystemInDarkTheme()) {
-                DemoScopedHiltInjectedViewModelComposable()
-            }
-        }
-        printComposeUiTreeToLog()
-
-        // When one Composable with a scoped ViewModel is not part of composition anymore and disposed
-        val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
-        advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
-        printComposeUiTreeToLog()
-        val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
-
-        // Then the Hilt Injected ViewModel disappears because it was only available in light mode
-        onNodeWithTestTag("Hilt FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
-        // And the scoped ViewModel is cleared
-        assert(finalAmountOfViewModelsCleared == initialAmountOfViewModelsCleared + 1) {
-            "The amount of FakeInjectedViewModel that were cleared after disposal ($finalAmountOfViewModelsCleared) " +
-                    "was not higher that the amount before disposal ($initialAmountOfViewModelsCleared)"
-        }
-    }
 }

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/hilt/ClearScopedViewModelTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/hilt/ClearScopedViewModelTests.kt
@@ -1,7 +1,6 @@
 package com.sebaslogen.resacaapp.sample.hilt
 
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Text
 import androidx.compose.runtime.getValue
@@ -29,7 +28,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @HiltAndroidTest

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/hilt/ComposeActivityRecreationTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/hilt/ComposeActivityRecreationTests.kt
@@ -1,6 +1,7 @@
 package com.sebaslogen.resacaapp.sample.hilt
 
 import android.content.Intent
+import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -37,8 +38,7 @@ class ComposeActivityRecreationTests : ComposeTestUtils {
                 retrieveTextFromNodeWithTestTag("Hilt FakeInjectedViewModel Scoped")
 
                 // When I change to night mode and apply the configuration change by recreating the Activity
-                RuntimeEnvironment.setQualifiers("+night")
-                activity.recreate()
+                RuntimeEnvironment.setQualifiers("+night") // This triggers activity re-creation
                 printComposeUiTreeToLog()
 
                 // Then the scoped object is still the same but the Hilt Injected ViewModel disappears

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/koin/ClearScopedViewModelTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/koin/ClearScopedViewModelTests.kt
@@ -201,43 +201,4 @@ class ClearScopedViewModelTests : ComposeTestUtils {
                     "was not two numbers higher that the amount before the key change ($initialAmountOfViewModelsCleared)"
         }
     }
-
-    @Test
-    fun `when I switch from light mode to night mode, then the one and only scoped ViewModel that's only used in light mode is gone`() = runTest {
-        // Given the starting screen with ViewModel scoped that is ONLY shown in light mode
-        composeTestRule.activity.setContent {
-            Text("Demo text")
-            if (!isSystemInDarkTheme()) {
-                DemoScopedKoinInjectedViewModelComposable()
-            }
-        }
-        printComposeUiTreeToLog()
-        // Find the scoped text fields and grab their texts
-        retrieveTextFromNodeWithTestTag("Koin FakeInjectedViewModel Scoped")
-        advanceTimeBy(1000) // Give time to the ObserveLifecycleWithScopedViewModelContainer to execute lifecycle.addObserver on main thread
-
-        // When I change to night mode and apply the configuration change by recreating the Activity
-        RuntimeEnvironment.setQualifiers("+night") // This triggers activity re-creation
-        composeTestRule.activity.setContent { // Almost empty screen in night mode
-            Text("Demo text")
-            if (!isSystemInDarkTheme()) {
-                DemoScopedKoinInjectedViewModelComposable()
-            }
-        }
-        printComposeUiTreeToLog()
-
-        // When one Composable with a scoped ViewModel is not part of composition anymore and disposed
-        val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
-        advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
-        printComposeUiTreeToLog()
-        val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
-
-        // Then the Koin Injected ViewModel disappears because it was only available in light mode
-        onNodeWithTestTag("Koin FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
-        // And the scoped ViewModel is cleared
-        assert(finalAmountOfViewModelsCleared == initialAmountOfViewModelsCleared + 1) {
-            "The amount of FakeInjectedViewModel that were cleared after disposal ($finalAmountOfViewModelsCleared) " +
-                    "was not higher that the amount before disposal ($initialAmountOfViewModelsCleared)"
-        }
-    }
 }

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/koin/ClearScopedViewModelTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/koin/ClearScopedViewModelTests.kt
@@ -93,7 +93,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
         composablesShown = false // Trigger disposal
         printComposeUiTreeToLog() // Required to trigger recomposition
         onNodeWithTestTag("Koin FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
-        advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+        advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
         printComposeUiTreeToLog()
         val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 
@@ -126,7 +126,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
             val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
             composablesShown = false // Trigger disposal
             composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
-            advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
             printComposeUiTreeToLog()
             val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 
@@ -159,7 +159,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
             val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
             composablesShown = false // Trigger disposal
             composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
-            advanceTimeBy(6000) // Advance more than 5 seconds to pass the disposal delay on ScopedViewModelContainer
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
             printComposeUiTreeToLog()
             val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/koin/ComposeActivityRecreationTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/koin/ComposeActivityRecreationTests.kt
@@ -7,14 +7,17 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.sebaslogen.resaca.COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS
 import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
 import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity.Companion.START_DESTINATION
+import com.sebaslogen.resacaapp.sample.ui.main.koinSingleViewModelScopedDestination
 import com.sebaslogen.resacaapp.sample.ui.main.koinViewModelScopedDestination
+import com.sebaslogen.resacaapp.sample.ui.main.showSingleScopedViewModel
 import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
+import com.sebaslogen.resacaapp.sample.viewModelsClearedGloballySharedCounter
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(AndroidJUnit4::class)
 class ComposeActivityRecreationTests : ComposeTestUtils {
@@ -24,20 +27,20 @@ class ComposeActivityRecreationTests : ComposeTestUtils {
 
     @Test
     fun `when I switch from light mode to night mode, then the Koin injected scoped ViewModel that's only used in light mode is gone`() {
-
-        // Given the starting screen with Koin injected ViewModel scoped that is ONLY shown in light mode
+        // Given the starting screen with Koin ViewModel scoped that is ONLY shown in light mode
         val launchIntent = Intent(ApplicationProvider.getApplicationContext(), ComposeActivity::class.java).apply {
             putExtra(START_DESTINATION, koinViewModelScopedDestination)
         }
         ActivityScenario.launch<ComposeActivity>(launchIntent).use { scenario ->
             scenario.onActivity { activity: ComposeActivity ->
-                printComposeUiTreeToLog()
                 // Find the scoped text fields and grab their texts
                 val initialFakeScopedRepoText = retrieveTextFromNodeWithTestTag("FakeRepo Scoped")
                 retrieveTextFromNodeWithTestTag("Koin FakeInjectedViewModel Scoped")
+                printComposeUiTreeToLog()
 
                 // When I change to night mode and apply the configuration change by recreating the Activity
-                RuntimeEnvironment.setQualifiers("+night") // This triggers activity re-creation
+                showSingleScopedViewModel = false // This is a fake night-mode change but it will remove Composable after Activity re-creation
+                activity.recreate()
                 printComposeUiTreeToLog()
 
                 // Then the scoped object is still the same but the Koin Injected ViewModel disappears
@@ -69,6 +72,37 @@ class ComposeActivityRecreationTests : ComposeTestUtils {
                 // Then the scoped objects are still the same
                 onNodeWithTestTag("FakeRepo Scoped").assertIsDisplayed().assertTextEquals(initialFakeScopedRepoText)
                 onNodeWithTestTag("Koin FakeInjectedViewModel Scoped").assertIsDisplayed().assertTextEquals(initialKoinFakeScopedViewModelText)
+            }
+        }
+    }
+
+    @Test
+    fun `when I switch from light mode to night mode, then the one and only Koin scoped ViewModel that's only used in light mode is gone`() {
+        // Given the starting screen with ViewModel scoped that is ONLY shown in light mode
+        val launchIntent = Intent(ApplicationProvider.getApplicationContext(), ComposeActivity::class.java).apply {
+            putExtra(START_DESTINATION, koinSingleViewModelScopedDestination)
+        }
+        ActivityScenario.launch<ComposeActivity>(launchIntent).use { scenario ->
+            scenario.onActivity { activity: ComposeActivity ->
+                // Find the scoped text fields and grab their texts
+                retrieveTextFromNodeWithTestTag("Koin FakeInjectedViewModel Scoped")
+                val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
+                printComposeUiTreeToLog()
+
+                // When I change to night mode and apply the configuration change by recreating the Activity
+                showSingleScopedViewModel = false // This is a fake night-mode change but it will remove Composable after Activity re-creation
+                activity.recreate()
+                printComposeUiTreeToLog()
+                Thread.sleep(COMPOSITION_RESUMED_TIMEOUT_IN_SECONDS * 1000) // Wait for the ViewModel to be cleared
+                printComposeUiTreeToLog() // Second print is needed to push the main thread forward
+                val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
+
+                // Then the scoped ViewModel disappears
+                onNodeWithTestTag("Koin FakeInjectedViewModel Scoped", assertDisplayed = false).assertDoesNotExist()
+                assert(finalAmountOfViewModelsCleared == initialAmountOfViewModelsCleared + 1) {
+                    "The amount of FakeInjectedViewModel that were cleared after key change ($finalAmountOfViewModelsCleared) " +
+                            "was not higher that the amount before the key change ($initialAmountOfViewModelsCleared)"
+                }
             }
         }
     }

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/koin/ComposeActivityRecreationTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/koin/ComposeActivityRecreationTests.kt
@@ -37,8 +37,7 @@ class ComposeActivityRecreationTests : ComposeTestUtils {
                 retrieveTextFromNodeWithTestTag("Koin FakeInjectedViewModel Scoped")
 
                 // When I change to night mode and apply the configuration change by recreating the Activity
-                RuntimeEnvironment.setQualifiers("+night")
-                activity.recreate()
+                RuntimeEnvironment.setQualifiers("+night") // This triggers activity re-creation
                 printComposeUiTreeToLog()
 
                 // Then the scoped object is still the same but the Koin Injected ViewModel disappears


### PR DESCRIPTION
See #5 

### TODO
- [x] Move Activity recreation tests to Espresso, Robolectric lifecycle seems to not match the one on a real Android
- [x] Clean up logs
- [x] Update readme