### PR TITLE
CHANGE blocking marks for disposal to run on single thread(main) 

### DIFF
--- a/resaca/src/commonMain/kotlin/com/sebaslogen/resaca/ScopedViewModelContainer.kt
+++ b/resaca/src/commonMain/kotlin/com/sebaslogen/resaca/ScopedViewModelContainer.kt
@@ -237,7 +237,8 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
         creationExtras = creationExtras,
         scopedObjectsContainer = scopedObjectsContainer,
         scopedObjectKeys = scopedObjectKeys,
-        cancelDisposal = ::cancelDisposal
+        cancelDisposal = ::cancelDisposal,
+        clearLastDisposedViewModel = ::clearLastDisposedObject
     )
 
     /**
@@ -336,7 +337,9 @@ public class ScopedViewModelContainer : ViewModel(), LifecycleEventObserver {
      * An object that is being disposed should also be cleared only if it was the last instance present in this container
      */
     private fun clearLastDisposedObject(disposedObject: Any, objectsContainer: List<Any> = scopedObjectsContainer.values.toList()) {
-        ScopedViewModelUtils.clearLastDisposedObject(disposedObject, objectsContainer)
+        threadSafeRunnerOnMain {
+            ScopedViewModelUtils.clearLastDisposedObject(disposedObject, objectsContainer)
+        }
     }
 
     private fun cancelDisposal(key: InternalKey) {

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearRememberScopedObjectTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearRememberScopedObjectTests.kt
@@ -12,9 +12,11 @@ import com.sebaslogen.resacaapp.sample.ui.main.compose.examples.DemoScopedObject
 import com.sebaslogen.resacaapp.sample.ui.main.data.FakeRepo
 import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
 import com.sebaslogen.resacaapp.sample.utils.MainDispatcherRule
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -103,7 +105,7 @@ class ClearRememberScopedObjectTests : ComposeTestUtils {
         }
 
     @Test
-    fun `when the keys associated with the Closeable change, then the scoped Closeable is closed`() {
+    fun `when the keys associated with the Closeable change, then the scoped Closeable is closed`() = runTest {
 
         // Given the starting screen with a scoped Closeable
         var closeableKey by mutableStateOf("initial key")
@@ -121,6 +123,10 @@ class ClearRememberScopedObjectTests : ComposeTestUtils {
         closeableKey = "new key" // Trigger disposal
         composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
         printComposeUiTreeToLog()
+
+        withContext(Dispatchers.Main) {
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
+        }
         val finalAmountOfCloseableCleared = closeableClosedGloballySharedCounter.get()
 
         // Then both scoped Closeable are cleared

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearScopedViewModelTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/ClearScopedViewModelTests.kt
@@ -18,9 +18,11 @@ import com.sebaslogen.resacaapp.sample.ui.main.data.FakeScopedViewModel
 import com.sebaslogen.resacaapp.sample.ui.main.rememberScopedDestination
 import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
 import com.sebaslogen.resacaapp.sample.utils.MainDispatcherRule
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,7 +52,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Test
-    fun `when I navigate to nested screen and back, then the 2 scoped ViewModels of the second screen are cleared`() {
+    fun `when I navigate to nested screen and back, then the 2 scoped ViewModels of the second screen are cleared`() = runTest {
 
         // Given the starting screen with scoped ViewModels
         composeTestRule.setContent {
@@ -64,6 +66,9 @@ class ClearScopedViewModelTests : ComposeTestUtils {
         val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
         printComposeUiTreeToLog()
         navController.popBackStack()
+        withContext(Dispatchers.Main) {
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
+        }
         printComposeUiTreeToLog() // This seems to be needed to trigger recomposition
         val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 
@@ -149,7 +154,7 @@ class ClearScopedViewModelTests : ComposeTestUtils {
     /////////////////////////////////////////////////////
 
     @Test
-    fun `when the keys associated with the ViewModels change, then the old scoped ViewModels are cleared`() {
+    fun `when the keys associated with the ViewModels change, then the old scoped ViewModels are cleared`() = runTest {
 
         // Given the starting screen with two scoped ViewModels
         var viewModelKey by mutableStateOf("initial key")
@@ -167,6 +172,9 @@ class ClearScopedViewModelTests : ComposeTestUtils {
         val initialAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
         viewModelKey = "new key" // Trigger disposal
         composeTestRule.onNodeWithText(textTitle).assertExists() // Required to trigger recomposition
+        withContext(Dispatchers.Main) {
+            advanceTimeBy(100) // Advance time to allow clear call on ScopedViewModelContainer to be processed before querying the counter
+        }
         printComposeUiTreeToLog()
         val finalAmountOfViewModelsCleared = viewModelsClearedGloballySharedCounter.get()
 


### PR DESCRIPTION
This is a fix for #131 
- Use coroutine scope + Main thread immediate for all object disposals
- Use Main thread for clearing closeable objects and ViewModels