### PR TITLE
Bugfix: Leak on backstack recreation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ subprojects {
     tasks.withType<KotlinJvmCompile>().configureEach {
         compilerOptions {
             jvmTarget = JvmTarget.JVM_17
+            freeCompilerArgs.add("-Xexpect-actual-classes")
             if (!project.name.contains(sampleModuleName)) {
                 freeCompilerArgs.add("-Xexplicit-api=strict")
             }

--- a/resaca/api/resaca.api
+++ b/resaca/api/resaca.api
@@ -84,6 +84,6 @@ public final class com/sebaslogen/resaca/ScopedViewModelContainer$InternalKey : 
 
 public final class com/sebaslogen/resaca/ScopedViewModelOwner {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;Landroidx/lifecycle/ViewModelStoreOwner;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;)V
 }
 

--- a/resaca/api/resaca.klib.api
+++ b/resaca/api/resaca.klib.api
@@ -7,7 +7,7 @@
 
 // Library unique name: <io.github.sebaslogen:resaca>
 final class <#A: androidx.lifecycle/ViewModel> com.sebaslogen.resaca/ScopedViewModelOwner { // com.sebaslogen.resaca/ScopedViewModelOwner|null[0]
-    constructor <init>(kotlin/String, kotlin.reflect/KClass<#A>, androidx.lifecycle/ViewModelProvider.Factory?, androidx.lifecycle.viewmodel/CreationExtras, androidx.lifecycle/ViewModelStoreOwner) // com.sebaslogen.resaca/ScopedViewModelOwner.<init>|<init>(kotlin.String;kotlin.reflect.KClass<1:0>;androidx.lifecycle.ViewModelProvider.Factory?;androidx.lifecycle.viewmodel.CreationExtras;androidx.lifecycle.ViewModelStoreOwner){}[0]
+    constructor <init>(kotlin/String, kotlin.reflect/KClass<#A>) // com.sebaslogen.resaca/ScopedViewModelOwner.<init>|<init>(kotlin.String;kotlin.reflect.KClass<1:0>){}[0]
 }
 
 final class <#A: kotlin/Any> com.sebaslogen.resaca/ScopeKeyWithResolver { // com.sebaslogen.resaca/ScopeKeyWithResolver|null[0]

--- a/resaca/src/androidMain/kotlin/com/sebaslogen/resaca/utils/WeakReference.android.kt
+++ b/resaca/src/androidMain/kotlin/com/sebaslogen/resaca/utils/WeakReference.android.kt
@@ -1,0 +1,3 @@
+package com.sebaslogen.resaca.utils
+
+internal actual typealias WeakReference<T> = java.lang.ref.WeakReference<T>

--- a/resaca/src/commonMain/kotlin/com/sebaslogen/resaca/utils/WeakReference.kt
+++ b/resaca/src/commonMain/kotlin/com/sebaslogen/resaca/utils/WeakReference.kt
@@ -1,0 +1,9 @@
+package com.sebaslogen.resaca.utils
+
+import kotlin.experimental.ExperimentalNativeApi
+
+@ExperimentalNativeApi // This must be propagated from the underlying native implementation.
+internal expect class WeakReference<T : Any>(referred: T) {
+    fun get(): T?
+    fun clear()
+}

--- a/resaca/src/nativeMain/kotlin/com/sebaslogen/resaca/utils/WeakReference.native.kt
+++ b/resaca/src/nativeMain/kotlin/com/sebaslogen/resaca/utils/WeakReference.native.kt
@@ -1,0 +1,6 @@
+package com.sebaslogen.resaca.utils
+
+import kotlin.experimental.ExperimentalNativeApi
+
+@OptIn(ExperimentalNativeApi::class)
+internal actual typealias WeakReference<T> = kotlin.native.ref.WeakReference<T>

--- a/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/MemoryLeakTests.kt
+++ b/sample/src/androidTest/java/com/sebaslogen/resacaapp/sample/MemoryLeakTests.kt
@@ -1,0 +1,67 @@
+package com.sebaslogen.resacaapp.sample
+
+import android.content.Intent
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
+import com.sebaslogen.resacaapp.sample.ui.main.rememberScopedDestination
+import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.ref.WeakReference
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+class MemoryLeakTests : ComposeTestUtils {
+
+    private lateinit var scenario: ActivityScenario<ComposeActivity>
+
+    @get:Rule
+    override val composeTestRule = createEmptyComposeRule()
+
+    @Before
+    fun setUp() {
+        scenario = ActivityScenario.launch(
+            Intent(ApplicationProvider.getApplicationContext(), ComposeActivity::class.java).apply {
+                putExtra(ComposeActivity.START_DESTINATION, rememberScopedDestination)
+            })
+    }
+
+    @Test
+    fun givenComposeActivityWithComposablesInANestedNavigationComposable_whenTheActivityIsRecreated_thenTheOriginalComposeActivityObjectIsGarbageCollected() {
+        var weakActivityReference: WeakReference<ComposeActivity>? = null
+        // Given I create the Activity
+        composeTestRule.waitForIdle()
+        scenario.onActivity { activity: ComposeActivity ->
+
+            // And we grab a WeakReference to the Activity
+            weakActivityReference = WeakReference(activity)
+        }
+        printComposeUiTreeToLog()
+
+        // And I click "Navigate to rememberScoped" to get to a nested screen in the same Activity
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("Navigate to rememberScoped").performClick()
+        printComposeUiTreeToLog()
+        composeTestRule.waitForIdle()
+
+        // When we recreate the activity
+        scenario.recreate()
+        composeTestRule.waitForIdle()
+
+        // And trigger Garbage Collection to make sure old ComposeActivity is collected
+        Runtime.getRuntime().gc()
+        printComposeUiTreeToLog()
+
+        // Then the original Activity object is garbage collected
+        assertNotNull(weakActivityReference) { "WeakReference container for initial ComposeActivity should not be null because it was created" }
+        assertNull(weakActivityReference?.get(), "Initial ComposeActivity should have been garbage collected but it wasn't, so it's leaking")
+    }
+}

--- a/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/ComposeActivity.kt
+++ b/sample/src/main/java/com/sebaslogen/resacaapp/sample/ui/main/ComposeActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -122,7 +123,7 @@ fun ScreensWithNavigation(navController: NavHostController = rememberNavControll
  */
 @Composable
 fun NavigationButtons(navController: NavHostController) {
-    Button(modifier = Modifier.padding(top = 16.dp, bottom = 2.dp),
+    Button(modifier = Modifier.padding(top = 16.dp, bottom = 2.dp).testTag("Navigate to rememberScoped"),
         onClick = { navController.navigate(rememberScopedDestination) }) {
         Text(text = "Push rememberScoped destination")
     }

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/MemoryLeakTests.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/MemoryLeakTests.kt
@@ -1,0 +1,62 @@
+package com.sebaslogen.resacaapp.sample
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.sebaslogen.resacaapp.sample.ui.main.ComposeActivity
+import com.sebaslogen.resacaapp.sample.ui.main.rememberScopedDestination
+import com.sebaslogen.resacaapp.sample.utils.ComposeTestUtils
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.ref.WeakReference
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+class MemoryLeakTests : ComposeTestUtils {
+    init {
+        callFromTestInit()
+    }
+
+    override fun callFromTestInit() {
+        ComposeActivity.defaultDestination = rememberScopedDestination // This is needed to reset the destination to the default one on the release app
+    }
+
+    @get:Rule
+    override val composeTestRule = createComposeRule()
+
+    @Test
+    fun `given ComposeActivity with Composables in a nested Navigation Composable, when the activity is recreated, then the original ComposeActivity object is garbage collected`() {
+        ActivityScenario.launch(ComposeActivity::class.java).use { scenario ->
+            var weakActivityReference: WeakReference<ComposeActivity>? = null
+            // Given I create the Activity and navigate to a nested screen
+            scenario.onActivity { activity: ComposeActivity ->
+
+                // Given the Activity shows a screen with scoped objects
+                printComposeUiTreeToLog()
+
+                // And I grab a WeakReference to the Activity
+                weakActivityReference = WeakReference(activity)
+
+                // And I click "Navigate to rememberScoped" to get to a nested screen in the same Activity
+                onNodeWithTestTag("Navigate to rememberScoped").performClick()
+                printComposeUiTreeToLog()
+            }
+
+            // When we recreate the activity
+            scenario.recreate().onActivity {
+
+                // And trigger Garbage Collection to make sure old ComposeActivity is collected
+                System.gc()
+                printComposeUiTreeToLog()
+
+                // Then the original Activity object is garbage collected
+                assertNotNull(weakActivityReference) { "WeakReference container for initial ComposeActivity should not be null because it was created" }
+                assertNull(weakActivityReference?.get(), "Initial ComposeActivity should have been garbage collected but it wasn't, so it's leaking")
+            }
+
+        }
+    }
+}

--- a/sample/src/test/java/com/sebaslogen/resacaapp/sample/ScopeKeysTest.kt
+++ b/sample/src/test/java/com/sebaslogen/resacaapp/sample/ScopeKeysTest.kt
@@ -23,7 +23,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class ScopeKeysTest : ComposeTestUtils {
     init {


### PR DESCRIPTION
Once a ViewModel is scoped in a destination that is in the backstack and a configuration change caused the Activity to be recreated, the ViewModel creationExtras was leaked (which references the NavBackStack entry which references the old Ativity)

Removed leaking references and added tests to prevent future regressions.